### PR TITLE
Release GOGUFW 1.2.0

### DIFF
--- a/App/app/app.c
+++ b/App/app/app.c
@@ -35,6 +35,7 @@
 #endif
 #ifdef ENABLE_FMRADIO
     #include "app/fm.h"
+    #include "ui/fmradio.h"
 #endif
 #include "app/generic.h"
 #include "app/main.h"
@@ -1861,7 +1862,7 @@ void APP_TimeSlice500ms(void)
 
 #ifdef ENABLE_FMRADIO
     if (gFmRadioMode && gScreenToDisplay == DISPLAY_FM && FM_UpdateRssiLevel())
-        gUpdateDisplay = true;
+        UI_UpdateFMRssiBar();
 #endif
 
 #ifdef ENABLE_FEAT_F4HWN_RX_TX_TIMER

--- a/App/app/fm.c
+++ b/App/app/fm.c
@@ -44,7 +44,6 @@ uint8_t           gFM_ChannelPosition;
 bool              gFM_FoundFrequency;
 uint16_t          gFM_RestoreCountdown_10ms;
 static uint8_t     s_fmRssiLevel = 0xFFu;
-static uint8_t     s_fmRssiCandidate = 0xFFu;
 
 #define FM_NAMES_FLASH_ADDR 0x013000u
 #define FM_NAMES_MAGIC      0x4747464Du  /* "GGFM" */
@@ -198,28 +197,26 @@ bool FM_UpdateRssiLevel(void)
     else
         level = (uint8_t)(1U + ((uint16_t)(rssi - 10U) * 4U) / 40U);
 
-    if (s_fmRssiLevel == 0xFFu) {
-        s_fmRssiLevel = level;
-        s_fmRssiCandidate = 0xFFu;
-        return true;
-    }
-
-    if (level == s_fmRssiLevel) {
-        s_fmRssiCandidate = 0xFFu;
+    if (level == s_fmRssiLevel)
         return false;
-    }
 
-    /* A raw RSSI value often jitters around a bar boundary.  Without this
-     * confirmation the visible level can alternate every 500 ms and force a
-     * full LCD redraw, which is audible as a periodic click in FM audio.
-     * Keep sampling live, but accept a new bar only after two matching reads. */
-    if (level != s_fmRssiCandidate) {
-        s_fmRssiCandidate = level;
-        return false;
+    /* Keep a small dead band around the 10/20/30/40/50 RSSI boundaries.
+     * Two matching samples are insufficient when a steady station repeatedly
+     * alternates across a boundary.  Hysteresis keeps the live meter responsive
+     * while preventing a 2 <-> 3 style redraw loop. */
+    if (s_fmRssiLevel <= 5u) {
+        if (level > s_fmRssiLevel) {
+            const uint8_t rise = (uint8_t)(10u * (s_fmRssiLevel + 1u) + 2u);
+            if (rssi < rise)
+                return false;
+        } else {
+            const uint8_t fall = (uint8_t)(10u * s_fmRssiLevel - 2u);
+            if (rssi > fall)
+                return false;
+        }
     }
 
     s_fmRssiLevel = level;
-    s_fmRssiCandidate = 0xFFu;
     return true;
 }
 
@@ -935,7 +932,6 @@ void FM_Play(void)
 void FM_Start(void)
 {
     s_fmRssiLevel = 0xFFu;
-    s_fmRssiCandidate = 0xFFu;
     gDualWatchActive          = false;
     gFmRadioMode              = true;
     gFM_ScanState             = FM_SCAN_OFF;

--- a/App/app/fm.c
+++ b/App/app/fm.c
@@ -44,6 +44,7 @@ uint8_t           gFM_ChannelPosition;
 bool              gFM_FoundFrequency;
 uint16_t          gFM_RestoreCountdown_10ms;
 static uint8_t     s_fmRssiLevel = 0xFFu;
+static uint8_t     s_fmRssiCandidate = 0xFFu;
 
 #define FM_NAMES_FLASH_ADDR 0x013000u
 #define FM_NAMES_MAGIC      0x4747464Du  /* "GGFM" */
@@ -197,10 +198,28 @@ bool FM_UpdateRssiLevel(void)
     else
         level = (uint8_t)(1U + ((uint16_t)(rssi - 10U) * 4U) / 40U);
 
-    if (level == s_fmRssiLevel)
+    if (s_fmRssiLevel == 0xFFu) {
+        s_fmRssiLevel = level;
+        s_fmRssiCandidate = 0xFFu;
+        return true;
+    }
+
+    if (level == s_fmRssiLevel) {
+        s_fmRssiCandidate = 0xFFu;
         return false;
+    }
+
+    /* A raw RSSI value often jitters around a bar boundary.  Without this
+     * confirmation the visible level can alternate every 500 ms and force a
+     * full LCD redraw, which is audible as a periodic click in FM audio.
+     * Keep sampling live, but accept a new bar only after two matching reads. */
+    if (level != s_fmRssiCandidate) {
+        s_fmRssiCandidate = level;
+        return false;
+    }
 
     s_fmRssiLevel = level;
+    s_fmRssiCandidate = 0xFFu;
     return true;
 }
 
@@ -916,6 +935,7 @@ void FM_Play(void)
 void FM_Start(void)
 {
     s_fmRssiLevel = 0xFFu;
+    s_fmRssiCandidate = 0xFFu;
     gDualWatchActive          = false;
     gFmRadioMode              = true;
     gFM_ScanState             = FM_SCAN_OFF;

--- a/App/app/main.c
+++ b/App/app/main.c
@@ -168,15 +168,115 @@ static void MAIN_SetQuietLocalMonitor(void)
         ( 2u << 0));       /* AF DAC gain */
 }
 
+static bool    s_call_preview_active;
+static uint8_t s_call_preview_tone;
+static uint8_t s_call_preview_note;
+static uint8_t s_call_preview_phase_ticks;
+static uint8_t s_call_preview_elapsed_ticks;
+static bool    s_call_preview_on_phase;
+
+static void MAIN_CallToneStopPreview(void)
+{
+    if (!s_call_preview_active) return;
+
+    s_call_preview_active = false;
+    AUDIO_AudioPathOff();
+    gEnableSpeaker = false;
+    BK4819_EnterTxMute();
+    BK4819_WriteRegister(BK4819_REG_70, 0x0000);
+
+    /* Restore the normal radio path through its authoritative setup routine.
+     * Its Messenger hook then performs the existing controlled FSK re-arm. */
+    RADIO_SelectVfos();
+    RADIO_SetupRegisters(true);
+}
+
+void MAIN_PlayCallTonePreview(uint8_t tone)
+{
+    if (tone > 4u) tone = 0u;
+    if (gCurrentFunction == FUNCTION_TRANSMIT || FUNCTION_IsRx()) return;
+
+    /* Moving between tones restarts the melody without repeatedly rebuilding
+     * the radio path.  The final cancel/timeout performs one controlled restore. */
+    if (!s_call_preview_active) {
+#ifdef ENABLE_MESSENGER
+        MSG_RF_HardRestoreVoicePath();
+#endif
+        BK4819_EnterTxMute();
+        BK4819_SetAF(BK4819_AF_BEEP);
+        MAIN_SetQuietLocalMonitor();
+        BK4819_WriteRegister(BK4819_REG_30, 0x0000);
+        BK4819_WriteRegister(BK4819_REG_30,
+            BK4819_REG_30_ENABLE_AF_DAC |
+            BK4819_REG_30_ENABLE_DISC_MODE |
+            BK4819_REG_30_ENABLE_TX_DSP);
+        AUDIO_AudioPathOn();
+        gEnableSpeaker = true;
+        s_call_preview_active = true;
+    } else {
+        BK4819_WriteRegister(BK4819_REG_70, 0x0000);
+    }
+
+    s_call_preview_tone = tone;
+    s_call_preview_note = 0u;
+    s_call_preview_phase_ticks = 0u;
+    s_call_preview_elapsed_ticks = 0u;
+    s_call_preview_on_phase = false;
+}
+
 void MAIN_CancelCallTonePreview(void)
 {
-    /* GGFW 0.6.5: CllTon preview was removed. Keep a safe no-op so
-     * stale menu transitions and tick hooks cannot affect audio/RF paths. */
+    MAIN_CallToneStopPreview();
 }
 
 void MAIN_CallToneTick10ms(void)
 {
-    /* No-op: CllTon preview removed. */
+    if (!s_call_preview_active) return;
+
+    if (gCurrentFunction == FUNCTION_TRANSMIT || FUNCTION_IsRx()) {
+        MAIN_CallToneStopPreview();
+        return;
+    }
+
+    /* A short sample is enough to identify each melody and completes before
+     * Messenger's existing 800 ms delayed re-arm window can expire. */
+    if (++s_call_preview_elapsed_ticks >= 70u) {
+        MAIN_CallToneStopPreview();
+        return;
+    }
+
+    if (s_call_preview_phase_ticks > 0u) {
+        --s_call_preview_phase_ticks;
+        return;
+    }
+
+    if (s_call_preview_note >= 16u) {
+        MAIN_CallToneStopPreview();
+        return;
+    }
+
+    const CallToneNote_t *n = &gCallToneMelodies[s_call_preview_tone][s_call_preview_note];
+    if (n->hz == 0u) {
+        MAIN_CallToneStopPreview();
+        return;
+    }
+
+    if (!s_call_preview_on_phase) {
+        BK4819_WriteRegister(BK4819_REG_71, MAIN_ScaleToneFreq(n->hz));
+        BK4819_WriteRegister(BK4819_REG_70,
+            BK4819_REG_70_ENABLE_TONE1 |
+            ((uint16_t)18u << BK4819_REG_70_SHIFT_TONE1_TUNING_GAIN));
+        BK4819_ExitTxMute();
+        s_call_preview_on_phase = true;
+        s_call_preview_phase_ticks = n->on_10ms;
+    } else {
+        /* Silence only the local tone generator between notes.  Do not cycle
+         * the TX link/mute state as that made earlier previews sound choppy. */
+        BK4819_WriteRegister(BK4819_REG_70, 0x0000);
+        s_call_preview_on_phase = false;
+        s_call_preview_phase_ticks = n->off_10ms;
+        ++s_call_preview_note;
+    }
 }
 
 static void MAIN_SendCallToneNote(uint16_t hz, uint8_t on_10ms, uint8_t off_10ms)

--- a/App/app/main.c
+++ b/App/app/main.c
@@ -168,10 +168,66 @@ static void MAIN_SetQuietLocalMonitor(void)
         ( 2u << 0));       /* AF DAC gain */
 }
 
-void MAIN_PlayCallTonePreview(uint8_t tone)
+typedef struct {
+    bool released;
+    KEY_Code_t candidate;
+    uint8_t stable_reads;
+} CallTonePreviewKeys_t;
+
+static KEY_Code_t MAIN_CallTonePreviewDelay(uint16_t delay_ms, CallTonePreviewKeys_t *keys)
+{
+    while (delay_ms > 0u) {
+        const uint16_t slice_ms = delay_ms > 10u ? 10u : delay_ms;
+        SYSTEM_DelayMs(slice_ms);
+        delay_ms -= slice_ms;
+
+        const KEY_Code_t key = KEYBOARD_Poll();
+        if (!keys->released) {
+            if (key == KEY_INVALID) {
+                if (++keys->stable_reads >= 2u) {
+                    keys->released = true;
+                    keys->stable_reads = 0u;
+                }
+            } else {
+                keys->stable_reads = 0u;
+            }
+            continue;
+        }
+
+        if (key != KEY_UP && key != KEY_DOWN &&
+            key != KEY_MENU && key != KEY_EXIT) {
+            keys->candidate = KEY_INVALID;
+            keys->stable_reads = 0u;
+            continue;
+        }
+
+        if (key != keys->candidate) {
+            keys->candidate = key;
+            keys->stable_reads = 1u;
+        } else if (++keys->stable_reads >= 2u) {
+            return key;
+        }
+    }
+
+    return KEY_INVALID;
+}
+
+static void MAIN_CallTonePreviewWaitForRelease(void)
+{
+    uint8_t released_reads = 0u;
+    while (released_reads < 2u) {
+        SYSTEM_DelayMs(10u);
+        if (KEYBOARD_Poll() == KEY_INVALID)
+            ++released_reads;
+        else
+            released_reads = 0u;
+    }
+}
+
+KEY_Code_t MAIN_PlayCallTonePreview(uint8_t tone)
 {
     if (tone > 4u) tone = 0u;
-    if (gCurrentFunction == FUNCTION_TRANSMIT || FUNCTION_IsRx()) return;
+    if (gCurrentFunction == FUNCTION_TRANSMIT || FUNCTION_IsRx()) return KEY_INVALID;
 
 #ifdef ENABLE_MESSENGER
     MSG_RF_HardRestoreVoicePath();
@@ -194,6 +250,12 @@ void MAIN_PlayCallTonePreview(uint8_t tone)
 
     uint16_t elapsed_ms = 0u;
     uint8_t note = 0u;
+    KEY_Code_t interrupted_by = KEY_INVALID;
+    CallTonePreviewKeys_t keys = {
+        .released = false,
+        .candidate = KEY_INVALID,
+        .stable_reads = 0u,
+    };
     while (elapsed_ms < 1200u) {
         if (note >= 16u || gCallToneMelodies[tone][note].hz == 0u) {
             note = 0u;
@@ -201,10 +263,16 @@ void MAIN_PlayCallTonePreview(uint8_t tone)
         }
         const CallToneNote_t *n = &gCallToneMelodies[tone][note];
 
-        BK4819_PlayToneRaw(n->hz, (uint16_t)n->on_10ms * 10u);
-        if (n->off_10ms > 0u) {
-            SYSTEM_DelayMs((uint16_t)n->off_10ms * 10u);
-        }
+        BK4819_WriteRegister(BK4819_REG_71, MAIN_ScaleToneFreq(n->hz));
+        BK4819_ExitTxMute();
+        interrupted_by = MAIN_CallTonePreviewDelay((uint16_t)n->on_10ms * 10u, &keys);
+        BK4819_EnterTxMute();
+        if (interrupted_by != KEY_INVALID) break;
+
+        if (n->off_10ms > 0u)
+            interrupted_by = MAIN_CallTonePreviewDelay((uint16_t)n->off_10ms * 10u, &keys);
+        if (interrupted_by != KEY_INVALID) break;
+
         elapsed_ms += (uint16_t)((uint16_t)n->on_10ms + n->off_10ms) * 10u;
         ++note;
     }
@@ -219,6 +287,15 @@ void MAIN_PlayCallTonePreview(uint8_t tone)
      * its normal controlled sidecar re-arm. */
     RADIO_SelectVfos();
     RADIO_SetupRegisters(true);
+
+    /* MENU/EXIT are handled after returning to the menu.  Consume their
+     * physical release here so the normal key scanner cannot deliver them a
+     * second time.  UP/DOWN immediately starts the next preview, which owns
+     * the still-held key until it is released. */
+    if (interrupted_by == KEY_MENU || interrupted_by == KEY_EXIT)
+        MAIN_CallTonePreviewWaitForRelease();
+
+    return interrupted_by;
 }
 
 void MAIN_CancelCallTonePreview(void)

--- a/App/app/main.c
+++ b/App/app/main.c
@@ -189,6 +189,9 @@ static void MAIN_CallToneStopPreview(void)
      * Its Messenger hook then performs the existing controlled FSK re-arm. */
     RADIO_SelectVfos();
     RADIO_SetupRegisters(true);
+#ifdef ENABLE_MESSENGER
+    MSG_RF_SetLocalTonePreviewActive(false);
+#endif
 }
 
 void MAIN_PlayCallTonePreview(uint8_t tone)
@@ -201,6 +204,7 @@ void MAIN_PlayCallTonePreview(uint8_t tone)
     if (!s_call_preview_active) {
 #ifdef ENABLE_MESSENGER
         MSG_RF_HardRestoreVoicePath();
+        MSG_RF_SetLocalTonePreviewActive(true);
 #endif
         BK4819_EnterTxMute();
         BK4819_SetAF(BK4819_AF_BEEP);

--- a/App/app/main.c
+++ b/App/app/main.c
@@ -194,7 +194,7 @@ void MAIN_PlayCallTonePreview(uint8_t tone)
 
     uint16_t elapsed_ms = 0u;
     uint8_t note = 0u;
-    while (elapsed_ms < 450u) {
+    while (elapsed_ms < 1200u) {
         if (note >= 16u || gCallToneMelodies[tone][note].hz == 0u) {
             note = 0u;
             if (gCallToneMelodies[tone][note].hz == 0u) break;

--- a/App/app/main.c
+++ b/App/app/main.c
@@ -152,7 +152,7 @@ static uint8_t MAIN_GetCallToneTxGain(void)
     /* Adjust only the BK4829 tone-generator amplitude.  Both values are used
      * by existing stable tone paths; do not touch REG_40 deviation or PA power. */
 #ifdef ENABLE_MESSENGER
-    if (gMessengerConfig.call_vol == 0u) return 16u;
+    if (gMessengerConfig.call_vol == 0u) return 4u;
 #endif
     return 66;
 }

--- a/App/app/main.c
+++ b/App/app/main.c
@@ -152,7 +152,7 @@ static uint8_t MAIN_GetCallToneTxGain(void)
     /* Adjust only the BK4829 tone-generator amplitude.  Both values are used
      * by existing stable tone paths; do not touch REG_40 deviation or PA power. */
 #ifdef ENABLE_MESSENGER
-    if (gMessengerConfig.call_vol == 0u) return 32u;
+    if (gMessengerConfig.call_vol == 0u) return 16u;
 #endif
     return 66;
 }

--- a/App/app/main.c
+++ b/App/app/main.c
@@ -206,16 +206,17 @@ void MAIN_PlayCallTonePreview(uint8_t tone)
         MSG_RF_HardRestoreVoicePath();
         MSG_RF_SetLocalTonePreviewActive(true);
 #endif
-        BK4819_EnterTxMute();
-        BK4819_SetAF(BK4819_AF_BEEP);
-        MAIN_SetQuietLocalMonitor();
-        BK4819_WriteRegister(BK4819_REG_30, 0x0000);
-        BK4819_WriteRegister(BK4819_REG_30,
-            BK4819_REG_30_ENABLE_AF_DAC |
-            BK4819_REG_30_ENABLE_DISC_MODE |
-            BK4819_REG_30_ENABLE_TX_DSP);
+        /* Use the same proven local-audio preparation sequence as the normal
+         * menu beep.  Earlier preview-only REG_48/REG_30 setup was silent on
+         * real UV-K1/BK4829 hardware even though its note timer was running. */
+        AUDIO_AudioPathOff();
+        if (gCurrentFunction == FUNCTION_POWER_SAVE && gRxIdleMode) {
+            BK4819_RX_TurnOn();
+        }
+        SYSTEM_DelayMs(20u);
+        BK4819_PrepareToPlayTone(true);
+        SYSTEM_DelayMs(2u);
         AUDIO_AudioPathOn();
-        gEnableSpeaker = true;
         s_call_preview_active = true;
     } else {
         BK4819_WriteRegister(BK4819_REG_70, 0x0000);
@@ -223,7 +224,9 @@ void MAIN_PlayCallTonePreview(uint8_t tone)
 
     s_call_preview_tone = tone;
     s_call_preview_note = 0u;
-    s_call_preview_phase_ticks = 0u;
+    /* Match AUDIO_PlayBeep(): allow the speaker/AF path roughly 60 ms to
+     * settle before unmuting the first tone. */
+    s_call_preview_phase_ticks = 6u;
     s_call_preview_elapsed_ticks = 0u;
     s_call_preview_on_phase = false;
 }
@@ -269,7 +272,7 @@ void MAIN_CallToneTick10ms(void)
         BK4819_WriteRegister(BK4819_REG_71, MAIN_ScaleToneFreq(n->hz));
         BK4819_WriteRegister(BK4819_REG_70,
             BK4819_REG_70_ENABLE_TONE1 |
-            ((uint16_t)18u << BK4819_REG_70_SHIFT_TONE1_TUNING_GAIN));
+            ((uint16_t)28u << BK4819_REG_70_SHIFT_TONE1_TUNING_GAIN));
         BK4819_ExitTxMute();
         s_call_preview_on_phase = true;
         s_call_preview_phase_ticks = n->on_10ms;

--- a/App/app/main.c
+++ b/App/app/main.c
@@ -149,39 +149,10 @@ static uint16_t MAIN_ScaleToneFreq(uint16_t freq)
 
 static uint8_t MAIN_GetCallToneTxGain(void)
 {
-    /* Keep tone-generator gain fixed. CllVol must not affect local sidetone;
-     * RF volume is tested only through a small temporary REG_40 deviation trim. */
-    return 96;
-}
-
-static uint16_t MAIN_CallToneApplyDeviationForVolume(void)
-{
-    uint16_t saved = BK4819_ReadRegister(0x40);
-    uint8_t vol = 1;
-#ifdef ENABLE_MESSENGER
-    vol = gMessengerConfig.call_vol;
-#endif
-    if (vol > 1u) vol = 1u;
-
-    /* BK4829 REG_40 deviation trim only. Keep PA bias/RF power untouched.
-     * LOW  = slightly below stock tone deviation for nearby/quiet use
-     * HIGH = previous successful MID test level
-     * Always restore immediately after CALLTX. */
-    uint16_t tuning = saved & 0x0FFFu;
-    if (vol == 0u) {
-        tuning = (tuning > 0x0080u) ? (uint16_t)(tuning - 0x0080u) : 0u;
-    } else {
-        tuning = (uint16_t)((tuning + 0x0080u > 0x0FFFu) ? 0x0FFFu : tuning + 0x0080u);
-    }
-
-    const uint16_t patched = (uint16_t)((saved & 0xE000u) | 0x1000u | tuning);
-    BK4819_WriteRegister(0x40, patched);
-    return saved;
-}
-
-static void MAIN_CallToneRestoreDeviation(uint16_t saved)
-{
-    BK4819_WriteRegister(0x40, saved);
+    /* Use the established BK4829 transmit-tone gain.  The previous gain of
+     * 96 plus a temporary REG_40 deviation lift could overdrive the receiver
+     * and make its squelch cycle as if the RF carrier were dropping. */
+    return 66;
 }
 
 static void MAIN_SetQuietLocalMonitor(void)
@@ -216,7 +187,8 @@ static void MAIN_SendCallToneNote(uint16_t hz, uint8_t on_10ms, uint8_t off_10ms
         BK4819_REG_70_ENABLE_TONE1 | ((uint16_t)(gain & 0x7fu) << BK4819_REG_70_SHIFT_TONE1_TUNING_GAIN));
     BK4819_ExitTxMute();
     SYSTEM_DelayMs((uint16_t)on_10ms * 10u);
-    BK4819_EnterTxMute();
+
+    /* Keep tone modulation and the TX link continuous between notes. */
     if (off_10ms) {
         SYSTEM_DelayMs((uint16_t)off_10ms * 10u);
     }
@@ -266,8 +238,6 @@ static void MAIN_SendPmrCallTone(void)
     BK4819_EnableTXLink();
     SYSTEM_DelayMs(80); // let TX/tone path settle before first tone
 
-    const uint16_t saved_reg40 = MAIN_CallToneApplyDeviationForVolume();
-
     /* Send for a full ~3 seconds. A single melody pass can be only around
      * 1.5-2.0s depending on the selected tone, so repeat the melody until the
      * requested call-tone duration is reached. */
@@ -283,8 +253,6 @@ static void MAIN_SendPmrCallTone(void)
         }
         if (!played_any) break;
     }
-
-    MAIN_CallToneRestoreDeviation(saved_reg40);
 
     AUDIO_AudioPathOff();
     gEnableSpeaker = false;

--- a/App/app/main.c
+++ b/App/app/main.c
@@ -149,9 +149,11 @@ static uint16_t MAIN_ScaleToneFreq(uint16_t freq)
 
 static uint8_t MAIN_GetCallToneTxGain(void)
 {
-    /* Use the established BK4829 transmit-tone gain.  The previous gain of
-     * 96 plus a temporary REG_40 deviation lift could overdrive the receiver
-     * and make its squelch cycle as if the RF carrier were dropping. */
+    /* Adjust only the BK4829 tone-generator amplitude.  Both values are used
+     * by existing stable tone paths; do not touch REG_40 deviation or PA power. */
+#ifdef ENABLE_MESSENGER
+    if (gMessengerConfig.call_vol == 0u) return 32u;
+#endif
     return 66;
 }
 

--- a/App/app/main.c
+++ b/App/app/main.c
@@ -168,122 +168,67 @@ static void MAIN_SetQuietLocalMonitor(void)
         ( 2u << 0));       /* AF DAC gain */
 }
 
-static bool    s_call_preview_active;
-static uint8_t s_call_preview_tone;
-static uint8_t s_call_preview_note;
-static uint8_t s_call_preview_phase_ticks;
-static uint8_t s_call_preview_elapsed_ticks;
-static bool    s_call_preview_on_phase;
-
-static void MAIN_CallToneStopPreview(void)
-{
-    if (!s_call_preview_active) return;
-
-    s_call_preview_active = false;
-    AUDIO_AudioPathOff();
-    gEnableSpeaker = false;
-    BK4819_EnterTxMute();
-    BK4819_WriteRegister(BK4819_REG_70, 0x0000);
-
-    /* Restore the normal radio path through its authoritative setup routine.
-     * Its Messenger hook then performs the existing controlled FSK re-arm. */
-    RADIO_SelectVfos();
-    RADIO_SetupRegisters(true);
-#ifdef ENABLE_MESSENGER
-    MSG_RF_SetLocalTonePreviewActive(false);
-#endif
-}
-
 void MAIN_PlayCallTonePreview(uint8_t tone)
 {
     if (tone > 4u) tone = 0u;
     if (gCurrentFunction == FUNCTION_TRANSMIT || FUNCTION_IsRx()) return;
 
-    /* Moving between tones restarts the melody without repeatedly rebuilding
-     * the radio path.  The final cancel/timeout performs one controlled restore. */
-    if (!s_call_preview_active) {
 #ifdef ENABLE_MESSENGER
-        MSG_RF_HardRestoreVoicePath();
-        MSG_RF_SetLocalTonePreviewActive(true);
+    MSG_RF_HardRestoreVoicePath();
 #endif
-        /* Use the same proven local-audio preparation sequence as the normal
-         * menu beep.  Earlier preview-only REG_48/REG_30 setup was silent on
-         * real UV-K1/BK4829 hardware even though its note timer was running. */
-        AUDIO_AudioPathOff();
-        if (gCurrentFunction == FUNCTION_POWER_SAVE && gRxIdleMode) {
-            BK4819_RX_TurnOn();
+
+    /* Deliberately synchronous and short.  This uses the exact local tone
+     * path proven by AUDIO_PlayBeep(), so no scheduler/FSK task can replace
+     * REG_30/70 while the sample is playing. */
+    AUDIO_AudioPathOff();
+    if (gCurrentFunction == FUNCTION_POWER_SAVE && gRxIdleMode) {
+        BK4819_RX_TurnOn();
+    }
+    SYSTEM_DelayMs(20u);
+
+    const uint16_t saved_reg71 = BK4819_ReadRegister(BK4819_REG_71);
+    BK4819_PrepareToPlayTone(true);
+    SYSTEM_DelayMs(2u);
+    AUDIO_AudioPathOn();
+    SYSTEM_DelayMs(60u);
+
+    uint16_t elapsed_ms = 0u;
+    uint8_t note = 0u;
+    while (elapsed_ms < 450u) {
+        if (note >= 16u || gCallToneMelodies[tone][note].hz == 0u) {
+            note = 0u;
+            if (gCallToneMelodies[tone][note].hz == 0u) break;
         }
-        SYSTEM_DelayMs(20u);
-        BK4819_PrepareToPlayTone(true);
-        SYSTEM_DelayMs(2u);
-        AUDIO_AudioPathOn();
-        s_call_preview_active = true;
-    } else {
-        BK4819_WriteRegister(BK4819_REG_70, 0x0000);
+        const CallToneNote_t *n = &gCallToneMelodies[tone][note];
+
+        BK4819_PlayToneRaw(n->hz, (uint16_t)n->on_10ms * 10u);
+        if (n->off_10ms > 0u) {
+            SYSTEM_DelayMs((uint16_t)n->off_10ms * 10u);
+        }
+        elapsed_ms += (uint16_t)((uint16_t)n->on_10ms + n->off_10ms) * 10u;
+        ++note;
     }
 
-    s_call_preview_tone = tone;
-    s_call_preview_note = 0u;
-    /* Match AUDIO_PlayBeep(): allow the speaker/AF path roughly 60 ms to
-     * settle before unmuting the first tone. */
-    s_call_preview_phase_ticks = 6u;
-    s_call_preview_elapsed_ticks = 0u;
-    s_call_preview_on_phase = false;
+    AUDIO_AudioPathOff();
+    SYSTEM_DelayMs(5u);
+    BK4819_TurnsOffTones_TurnsOnRX();
+    SYSTEM_DelayMs(5u);
+    BK4819_WriteRegister(BK4819_REG_71, saved_reg71);
+
+    /* Rebuild stock RX once, then let the existing Messenger hook perform
+     * its normal controlled sidecar re-arm. */
+    RADIO_SelectVfos();
+    RADIO_SetupRegisters(true);
 }
 
 void MAIN_CancelCallTonePreview(void)
 {
-    MAIN_CallToneStopPreview();
+    /* Synchronous preview has already stopped before key handling resumes. */
 }
 
 void MAIN_CallToneTick10ms(void)
 {
-    if (!s_call_preview_active) return;
-
-    if (gCurrentFunction == FUNCTION_TRANSMIT || FUNCTION_IsRx()) {
-        MAIN_CallToneStopPreview();
-        return;
-    }
-
-    /* A short sample is enough to identify each melody and completes before
-     * Messenger's existing 800 ms delayed re-arm window can expire. */
-    if (++s_call_preview_elapsed_ticks >= 70u) {
-        MAIN_CallToneStopPreview();
-        return;
-    }
-
-    if (s_call_preview_phase_ticks > 0u) {
-        --s_call_preview_phase_ticks;
-        return;
-    }
-
-    if (s_call_preview_note >= 16u) {
-        MAIN_CallToneStopPreview();
-        return;
-    }
-
-    const CallToneNote_t *n = &gCallToneMelodies[s_call_preview_tone][s_call_preview_note];
-    if (n->hz == 0u) {
-        MAIN_CallToneStopPreview();
-        return;
-    }
-
-    if (!s_call_preview_on_phase) {
-        BK4819_WriteRegister(BK4819_REG_71, MAIN_ScaleToneFreq(n->hz));
-        BK4819_WriteRegister(BK4819_REG_70,
-            BK4819_REG_70_ENABLE_TONE1 |
-            ((uint16_t)28u << BK4819_REG_70_SHIFT_TONE1_TUNING_GAIN));
-        BK4819_ExitTxMute();
-        s_call_preview_on_phase = true;
-        s_call_preview_phase_ticks = n->on_10ms;
-    } else {
-        /* Silence only the local tone generator between notes.  Do not cycle
-         * the TX link/mute state as that made earlier previews sound choppy. */
-        BK4819_WriteRegister(BK4819_REG_70, 0x0000);
-        s_call_preview_on_phase = false;
-        s_call_preview_phase_ticks = n->off_10ms;
-        ++s_call_preview_note;
-    }
+    /* Synchronous preview needs no periodic RF/audio owner. */
 }
 
 static void MAIN_SendCallToneNote(uint16_t hz, uint8_t on_10ms, uint8_t off_10ms)

--- a/App/app/main.h
+++ b/App/app/main.h
@@ -23,10 +23,10 @@
 extern bool gCallToneTxActive;
 
 void MAIN_ProcessKeys(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld);
+void MAIN_PlayCallTonePreview(uint8_t tone);
 void MAIN_CancelCallTonePreview(void);
 void MAIN_CallToneTick10ms(void);
 void MAIN_SendPmrCallToneAction(void);
 void channelMoveSwitch(void);
 
 #endif
-

--- a/App/app/main.h
+++ b/App/app/main.h
@@ -23,7 +23,7 @@
 extern bool gCallToneTxActive;
 
 void MAIN_ProcessKeys(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld);
-void MAIN_PlayCallTonePreview(uint8_t tone);
+KEY_Code_t MAIN_PlayCallTonePreview(uint8_t tone);
 void MAIN_CancelCallTonePreview(void);
 void MAIN_CallToneTick10ms(void);
 void MAIN_SendPmrCallToneAction(void);

--- a/App/app/menu.c
+++ b/App/app/menu.c
@@ -2257,6 +2257,10 @@ static void MENU_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction)
             if (m == MENU_CALL_TONE) {
                 if (gSubMenuSelection < 0) gSubMenuSelection = 0;
                 if (gSubMenuSelection > 4) gSubMenuSelection = 4;
+                /* The normal UP/DOWN beep runs after key handling and resets
+                 * BK4829's local tone path.  The melody itself is the feedback
+                 * for this menu item, so do not let that beep cancel it. */
+                gBeepToPlay = BEEP_NONE;
                 MAIN_PlayCallTonePreview((uint8_t)gSubMenuSelection);
             }
 #endif

--- a/App/app/menu.c
+++ b/App/app/menu.c
@@ -2255,18 +2255,36 @@ static void MENU_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction)
             MENU_ClampSelection(Direction);
 #ifdef ENABLE_MESSENGER
             if (m == MENU_CALL_TONE) {
-                if (gSubMenuSelection < 0) gSubMenuSelection = 0;
-                if (gSubMenuSelection > 4) gSubMenuSelection = 4;
-                /* The normal UP/DOWN beep runs after key handling and resets
-                 * BK4829's local tone path.  The melody itself is the feedback
-                 * for this menu item, so do not let that beep cancel it. */
-                gBeepToPlay = BEEP_NONE;
-                /* The preview is intentionally synchronous.  Render the new
-                 * selection first so the screen never appears stuck on the
-                 * previous tone while its 1.2 s sample is playing. */
-                gRequestDisplayScreen = DISPLAY_MENU;
-                GUI_DisplayScreen();
-                MAIN_PlayCallTonePreview((uint8_t)gSubMenuSelection);
+                for (;;) {
+                    if (gSubMenuSelection < 0) gSubMenuSelection = 0;
+                    if (gSubMenuSelection > 4) gSubMenuSelection = 4;
+                    /* The melody itself replaces the normal navigation beep. */
+                    gBeepToPlay = BEEP_NONE;
+                    /* Render first; the synchronous sample must never leave
+                     * the previous tone name visible. */
+                    gRequestDisplayScreen = DISPLAY_MENU;
+                    GUI_DisplayScreen();
+
+                    const KEY_Code_t preview_key =
+                        MAIN_PlayCallTonePreview((uint8_t)gSubMenuSelection);
+
+                    if (preview_key == KEY_UP || preview_key == KEY_DOWN) {
+                        int8_t preview_direction = preview_key == KEY_UP ? 1 : -1;
+                        if (!gEeprom.SET_NAV && gIsInSubMenu)
+                            preview_direction = -preview_direction;
+                        MENU_ClampSelection(preview_direction);
+                        continue;
+                    }
+                    if (preview_key == KEY_MENU) {
+                        MENU_Key_MENU(true, false);
+                        return;
+                    }
+                    if (preview_key == KEY_EXIT) {
+                        MENU_Key_EXIT(true, false);
+                        return;
+                    }
+                    break;
+                }
             }
 #endif
             gRequestDisplayScreen = DISPLAY_MENU;

--- a/App/app/menu.c
+++ b/App/app/menu.c
@@ -2255,11 +2255,9 @@ static void MENU_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction)
             MENU_ClampSelection(Direction);
 #ifdef ENABLE_MESSENGER
             if (m == MENU_CALL_TONE) {
-                /* GGFW 0.6.3 final: CllTon preview was removed.  The menu now
-                 * behaves like a normal setting; users can hear the selected
-                 * melody with CALLTX after saving. */
                 if (gSubMenuSelection < 0) gSubMenuSelection = 0;
                 if (gSubMenuSelection > 4) gSubMenuSelection = 4;
+                MAIN_PlayCallTonePreview((uint8_t)gSubMenuSelection);
             }
 #endif
             gRequestDisplayScreen = DISPLAY_MENU;

--- a/App/app/menu.c
+++ b/App/app/menu.c
@@ -2261,6 +2261,11 @@ static void MENU_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction)
                  * BK4829's local tone path.  The melody itself is the feedback
                  * for this menu item, so do not let that beep cancel it. */
                 gBeepToPlay = BEEP_NONE;
+                /* The preview is intentionally synchronous.  Render the new
+                 * selection first so the screen never appears stuck on the
+                 * previous tone while its 1.2 s sample is playing. */
+                gRequestDisplayScreen = DISPLAY_MENU;
+                GUI_DisplayScreen();
                 MAIN_PlayCallTonePreview((uint8_t)gSubMenuSelection);
             }
 #endif

--- a/App/app/messenger_rf.c
+++ b/App/app/messenger_rf.c
@@ -58,6 +58,7 @@ extern uint8_t gFSKWriteIndex;
 #define MSG_RF_ACK_QUEUE_LEN             4u     /* 1.0.1: queue ACKs so delayed ACKs do not overwrite each other */
 #define MSG_RF_REPEAT_GAP_MS            100u   /* short gap between repeated FSK frames */
 #define MSG_RF_RANGE_WAIT_PONG_TICKS    1200u  /* 12 s same-channel PONG listen lock */
+#define MSG_RF_SQL_CLOSE_CONFIRM_TICKS     3u  /* 30 ms fallback when FSK sidecar masks SQL_FOUND */
 
 #define MSG_RF_REG59_RX_CLEAR        0x4068u
 #define MSG_RF_REG59_RX_ENABLE       0x3068u
@@ -83,6 +84,7 @@ static uint8_t s_sidecar_count;
 static uint8_t s_post_tx_restore_ticks;
 static uint8_t s_rearm_delay_ticks;
 static uint8_t s_rx_stale_ticks;
+static uint8_t s_sql_close_confirm_ticks;
 static uint8_t s_deferred_beep_ticks;
 static uint8_t s_deferred_beep_max_ticks;
 static bool s_deferred_beep_pending;
@@ -804,6 +806,26 @@ void MSG_RF_Tick10ms(void)
     if (gSurvivalMode) return;
     MSG_RF_EnsureStoreInitialized();
     MSG_RF_UpdateDebugSnapshot();
+
+    /* The FSK sidecar can occasionally leave the stock SQL_FOUND interrupt
+     * unseen after an analog/repeater tail.  REG_0C still reports that the
+     * channel is idle.  Confirm that state for 30 ms, outside an FSK capture,
+     * then feed only the missing close state back to the stock receive state
+     * machine.  HandleReceive() remains responsible for closing audio and
+     * rebuilding RX; do not restore speaker state or reset BK4829 here. */
+    if (gCurrentFunction == FUNCTION_RECEIVE &&
+        g_SquelchLost &&
+        !s_rx_capture_active &&
+        s_rx_stale_ticks == 0u &&
+        (s_dbg_0c & (1u << 1)) == 0u) {
+        if (++s_sql_close_confirm_ticks >= MSG_RF_SQL_CLOSE_CONFIRM_TICKS) {
+            s_sql_close_confirm_ticks = 0u;
+            g_SquelchLost = false;
+        }
+    } else {
+        s_sql_close_confirm_ticks = 0u;
+    }
+
     MSG_RF_RxChannelLockTick();
     MSG_RF_RangeBeepTick();
 

--- a/App/app/messenger_rf.c
+++ b/App/app/messenger_rf.c
@@ -98,6 +98,7 @@ static bool s_sidecar_armed;
 static bool s_rx_capture_active;
 static bool s_ignore_next_self_rx;
 static bool s_fsk_audio_muted;
+static bool s_local_tone_preview_active;
 static uint16_t s_fsk_audio_prev_reg48;
 static uint16_t s_unread_led_ticks;
 static bool s_unread_led_owner;
@@ -206,7 +207,7 @@ static bool MSG_RF_AutoTxBusy(void)
     /* UV-K5 parity: automatic ACK/PONG/retry must not collide with ordinary
      * channel activity.  Manual SEND still uses MSG_RF_FskBusy(), but all
      * automatic replies defer while squelch/carrier is open. */
-    return MSG_RF_FskBusy() || MSG_RF_ChannelBusy();
+    return s_local_tone_preview_active || MSG_RF_FskBusy() || MSG_RF_ChannelBusy();
 }
 
 static void MSG_RF_EnsureStoreInitialized(void)
@@ -469,6 +470,7 @@ static void MSG_RF_RequestDeferredBeep(void)
 static bool MSG_RF_CanPlayNotifyBeep(void)
 {
     if (!s_deferred_beep_pending) return false;
+    if (s_local_tone_preview_active) return false;
     if (gCurrentFunction == FUNCTION_TRANSMIT) return false;
     if (MSG_RF_ChannelBusy()) return false;
     if (s_rx_capture_active || s_rx_stale_ticks) return false;
@@ -494,6 +496,7 @@ static void MSG_RF_RequestAckSuccessBeep(void)
 static bool MSG_RF_CanPlayAckSuccessBeep(void)
 {
     if (!s_ack_success_beep_pending) return false;
+    if (s_local_tone_preview_active) return false;
     if (gCurrentFunction == FUNCTION_TRANSMIT) return false;
     if (MSG_RF_ChannelBusy()) return false;
     if (s_rx_capture_active || s_rx_stale_ticks) return false;
@@ -696,9 +699,18 @@ void MSG_RF_HardRestoreVoicePath(void)
     s_restore_count++;
 }
 
+void MSG_RF_SetLocalTonePreviewActive(bool active)
+{
+    /* A local-only melody temporarily owns BK4829 REG_30/70/71.  Keep the
+     * existing event-based FSK re-arm request pending until the melody ends;
+     * do not continuously touch any RF register from this guard. */
+    s_local_tone_preview_active = active;
+}
+
 static void MSG_RF_ArmSidecarIfIdle(void)
 {
 #ifdef ENABLE_AIRCOPY
+    if (s_local_tone_preview_active) return;
     if (!gMessengerConfig.msg_rx) return;
 #ifdef ENABLE_VOX
     /* VOX mode owns the microphone/voice RX path. While VOX is ON, do not arm
@@ -751,6 +763,7 @@ static void MSG_RF_RequestControlledReprime(uint8_t delay_ticks)
 
 static bool MSG_RF_CanControlledReprimeNow(void)
 {
+    if (s_local_tone_preview_active) return false;
     if (!gMessengerConfig.msg_rx) return false;
 #ifdef ENABLE_VOX
     if (gEeprom.VOX_SWITCH) return false;

--- a/App/app/messenger_rf.c
+++ b/App/app/messenger_rf.c
@@ -98,7 +98,6 @@ static bool s_sidecar_armed;
 static bool s_rx_capture_active;
 static bool s_ignore_next_self_rx;
 static bool s_fsk_audio_muted;
-static bool s_local_tone_preview_active;
 static uint16_t s_fsk_audio_prev_reg48;
 static uint16_t s_unread_led_ticks;
 static bool s_unread_led_owner;
@@ -207,7 +206,7 @@ static bool MSG_RF_AutoTxBusy(void)
     /* UV-K5 parity: automatic ACK/PONG/retry must not collide with ordinary
      * channel activity.  Manual SEND still uses MSG_RF_FskBusy(), but all
      * automatic replies defer while squelch/carrier is open. */
-    return s_local_tone_preview_active || MSG_RF_FskBusy() || MSG_RF_ChannelBusy();
+    return MSG_RF_FskBusy() || MSG_RF_ChannelBusy();
 }
 
 static void MSG_RF_EnsureStoreInitialized(void)
@@ -470,7 +469,6 @@ static void MSG_RF_RequestDeferredBeep(void)
 static bool MSG_RF_CanPlayNotifyBeep(void)
 {
     if (!s_deferred_beep_pending) return false;
-    if (s_local_tone_preview_active) return false;
     if (gCurrentFunction == FUNCTION_TRANSMIT) return false;
     if (MSG_RF_ChannelBusy()) return false;
     if (s_rx_capture_active || s_rx_stale_ticks) return false;
@@ -496,7 +494,6 @@ static void MSG_RF_RequestAckSuccessBeep(void)
 static bool MSG_RF_CanPlayAckSuccessBeep(void)
 {
     if (!s_ack_success_beep_pending) return false;
-    if (s_local_tone_preview_active) return false;
     if (gCurrentFunction == FUNCTION_TRANSMIT) return false;
     if (MSG_RF_ChannelBusy()) return false;
     if (s_rx_capture_active || s_rx_stale_ticks) return false;
@@ -699,18 +696,9 @@ void MSG_RF_HardRestoreVoicePath(void)
     s_restore_count++;
 }
 
-void MSG_RF_SetLocalTonePreviewActive(bool active)
-{
-    /* A local-only melody temporarily owns BK4829 REG_30/70/71.  Keep the
-     * existing event-based FSK re-arm request pending until the melody ends;
-     * do not continuously touch any RF register from this guard. */
-    s_local_tone_preview_active = active;
-}
-
 static void MSG_RF_ArmSidecarIfIdle(void)
 {
 #ifdef ENABLE_AIRCOPY
-    if (s_local_tone_preview_active) return;
     if (!gMessengerConfig.msg_rx) return;
 #ifdef ENABLE_VOX
     /* VOX mode owns the microphone/voice RX path. While VOX is ON, do not arm
@@ -763,7 +751,6 @@ static void MSG_RF_RequestControlledReprime(uint8_t delay_ticks)
 
 static bool MSG_RF_CanControlledReprimeNow(void)
 {
-    if (s_local_tone_preview_active) return false;
     if (!gMessengerConfig.msg_rx) return false;
 #ifdef ENABLE_VOX
     if (gEeprom.VOX_SWITCH) return false;

--- a/App/app/messenger_rf.h
+++ b/App/app/messenger_rf.h
@@ -11,6 +11,7 @@ void MSG_RF_OnRadioInterrupt(uint16_t status);
 bool MSG_RF_SendText(const char *text);
 bool MSG_RF_SendRangePing(void);
 void MSG_RF_HardRestoreVoicePath(void);
+void MSG_RF_SetLocalTonePreviewActive(bool active);
 void MSG_RF_PrepareVoxVoiceTx(void);
 void MSG_RF_OnVoxModeChanged(bool enabled);
 void MSG_RF_OnRadioSetupRegisters(void);

--- a/App/app/messenger_rf.h
+++ b/App/app/messenger_rf.h
@@ -11,7 +11,6 @@ void MSG_RF_OnRadioInterrupt(uint16_t status);
 bool MSG_RF_SendText(const char *text);
 bool MSG_RF_SendRangePing(void);
 void MSG_RF_HardRestoreVoicePath(void);
-void MSG_RF_SetLocalTonePreviewActive(bool active);
 void MSG_RF_PrepareVoxVoiceTx(void);
 void MSG_RF_OnVoxModeChanged(bool enabled);
 void MSG_RF_OnRadioSetupRegisters(void);

--- a/App/app/messenger_store.h
+++ b/App/app/messenger_store.h
@@ -49,7 +49,7 @@ typedef struct {
     // Added at the END only. Do not insert new fields before next_msg_id/callsign/drafts;
     // older builds store these fields by raw struct offset.
     uint8_t call_tone;   // 0..4, CllTon menu
-    uint8_t call_vol;    // 0=LOW, 1=HIGH, CllVol REG40 deviation trim
+    uint8_t call_vol;    // 0=LOW, 1=HIGH, CALLTX tone-generator gain
     uint8_t rng_rsp;     // 0=OFF, 1=ON automatic Range Check PONG response
 } MSG_Config_t;
 

--- a/App/ui/fmradio.c
+++ b/App/ui/fmradio.c
@@ -143,6 +143,19 @@ static void FM_UI_DrawRssiBars(void)
     }
 }
 
+void UI_UpdateFMRssiBar(void)
+{
+    if (FM_IsNameEditActive() || FM_IsAutoScanConfirmActive())
+        return;
+
+    /* The meter occupies x=106..124 entirely on framebuffer page 6
+     * (display y=48..55).  Update only that page instead of retransmitting
+     * all seven FM pages whenever the visible RSSI level changes. */
+    memset(&gFrameBuffer[6][106], 0, 19);
+    FM_UI_DrawRssiBars();
+    ST7565_BlitLine(6);
+}
+
 static void FM_UI_DrawEditName(void)
 {
     char buf[20];

--- a/App/ui/fmradio.c
+++ b/App/ui/fmradio.c
@@ -149,11 +149,11 @@ void UI_UpdateFMRssiBar(void)
         return;
 
     /* The meter occupies x=106..124 entirely on framebuffer page 6
-     * (display y=48..55).  Update only that page instead of retransmitting
-     * all seven FM pages whenever the visible RSSI level changes. */
+     * (LCD page 7, after the status page).  Transfer only those 19 columns;
+     * even a full 128-column page produces an audible pulse in quiet FM audio. */
     memset(&gFrameBuffer[6][106], 0, 19);
     FM_UI_DrawRssiBars();
-    ST7565_BlitLine(6);
+    ST7565_DrawLine(106, 7, &gFrameBuffer[6][106], 19);
 }
 
 static void FM_UI_DrawEditName(void)

--- a/App/ui/fmradio.h
+++ b/App/ui/fmradio.h
@@ -19,7 +19,7 @@
 
 #ifdef ENABLE_FMRADIO
     void UI_DisplayFM(void);
+    void UI_UpdateFMRssiBar(void);
 #endif
 
 #endif
-

--- a/Gogufw_1.2.0_chirp_module.py
+++ b/Gogufw_1.2.0_chirp_module.py
@@ -1,4 +1,4 @@
-# GOGUFW UV-K1 Messenger CHIRP module v1.0.1a
+# GOGUFW UV-K1 / UV-K5 V3 Messenger CHIRP module v1.2.0
 # Based on F4HWN Fusion CHIRP 5.5.0 support.
 # Matches GOGUFW 1.0.1 EEPROM aliases:
 #   FM names: 0x00D000 alias -> firmware flash 0x013000
@@ -1214,7 +1214,7 @@ def _ggfw_msg_config_ensure(_mem):
 class UVK5RadioEgzumer(chirp_common.CloneModeRadio):
     """Quansheng UV-K5 (egzumer + f4hwn)"""
     VENDOR = "Quansheng"
-    MODEL = "UV-K1 GOGUFW Messenger 1.0.1a"
+    MODEL = "UV-K1 / UV-K5 V3 GOGUFW Messenger 1.2.0"
     BAUD_RATE = 38400
     NEEDS_COMPAT_SERIAL = False
     FIRMWARE_VERSION = ""

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GOGUFW is a messaging-focused firmware for the Quansheng UV-K1 / UV-K5 V3 hardwa
 
 The project is derived from F4HWN Fusion and currently incorporates selected changes through F4HWN 5.9.0. It is not a clean upstream tree: Messenger reliability and compatibility with existing GOGUFW radios take priority over broad feature merges.
 
-> The `1.2.0` line is the current development line. The preserved pre-development baseline is tagged `v1.1.2-known-good`.
+> `1.2.0` is the current stable release. The preserved pre-development baseline is tagged `v1.1.2-known-good`.
 
 ## Main features
 


### PR DESCRIPTION
## Summary

- fixes missed squelch close after Messenger FSK RX
- keeps CALLTX modulation continuous and makes LOW/HIGH tone volume effective
- adds 1.2-second, keyboard-interruptible call-tone previews
- keeps live FM RSSI while adding hysteresis and limiting LCD updates to the 19-column meter region
- packages the synchronized GOGUFW 1.2.0 CHIRP module
- marks 1.2.0 as the stable release

## Hardware validation

- repeater-tail squelch close: passed
- CALLTX continuous carrier/modulation: passed
- CALLTX LOW/HIGH level separation: passed
- call-tone preview, navigation and MENU/EXIT interruption: passed
- FM RSSI remains live; periodic click is greatly reduced, with a faint residual click accepted for this release
- previously checked Messenger/Range/voice regressions: no reported regression

## Validation

- Fusion clean build succeeds
- CHIRP module Python syntax succeeds
- CHIRP key actions match firmware: MESSENGER=24, HEARD=25, CALLTX=26

## Build

- FLASH: 119772 / 120832 bytes (99.12%)
- RAM: 15296 / 16384 bytes (93.36%)
- release BIN SHA-256: cf49458e9f86b66b06d6f0725c2bfc00909f2b258b05191c7dd436439a8a34bb
- CHIRP module SHA-256: b325d87e95984090849ba9daccae22d1fb2b40bb069ad3e1d047a59378b6266c